### PR TITLE
Fix silent import stalls and progress reporting

### DIFF
--- a/includes/abstracts/class-geodir-converter-importer.php
+++ b/includes/abstracts/class-geodir-converter-importer.php
@@ -32,7 +32,47 @@ abstract class GeoDir_Converter_Importer {
 	 *
 	 * @var int
 	 */
-	const BATCH_SIZE = 1000;
+	const BATCH_SIZE = 100;
+
+	/**
+	 * Lower bound applied to a filtered batch size.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	const MIN_BATCH_SIZE = 1;
+
+	/**
+	 * Upper bound applied to a filtered batch size.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	const MAX_BATCH_SIZE = 1000;
+
+	/**
+	 * Number of items processed between flushes of buffered progress.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	const FLUSH_INTERVAL = 10;
+
+	/**
+	 * Number of attempts before an item is treated as fatal and skipped.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	const MAX_ITEM_ATTEMPTS = 2;
+
+	/**
+	 * Maximum number of log entries retained for an import.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	const MAX_LOG_ENTRIES = 1000;
 
 	/**
 	 * Action identifier for importing categories.
@@ -181,6 +221,58 @@ abstract class GeoDir_Converter_Importer {
 	 * @var array
 	 */
 	private $logs_buffer = array();
+
+	/**
+	 * Number of items processed since buffered progress was last flushed.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	private $items_since_flush = 0;
+
+	/**
+	 * Pending resume point for the current paginated task.
+	 *
+	 * @since 2.2.1
+	 * @var array|null
+	 */
+	private $pending_checkpoint = null;
+
+	/**
+	 * The item currently being processed, mirrored to the database so a hard
+	 * crash can be attributed to it on the next attempt.
+	 *
+	 * @since 2.2.1
+	 * @var array|null
+	 */
+	private $in_flight_item = null;
+
+	/**
+	 * Marker left behind by a previous, interrupted attempt.
+	 *
+	 * Read once per request and held unchanged, so every item in the batch is
+	 * compared against the record that actually crashed.
+	 *
+	 * @since 2.2.1
+	 * @var array|null
+	 */
+	private $crashed_item = null;
+
+	/**
+	 * Whether the crashed-item marker has been read this request.
+	 *
+	 * @since 2.2.1
+	 * @var bool
+	 */
+	private $crashed_item_loaded = false;
+
+	/**
+	 * Cache addition state captured before a task suspended it.
+	 *
+	 * @since 2.2.1
+	 * @var bool
+	 */
+	private $cache_addition_suspended = false;
 
 	/**
 	 * Background process instance.
@@ -530,7 +622,9 @@ abstract class GeoDir_Converter_Importer {
 	 * @return int The batch size.
 	 */
 	public function get_batch_size() {
-		return (int) apply_filters( "geodir_converter_{$this->importer_id}_batch_size", self::BATCH_SIZE );
+		$batch_size = (int) apply_filters( "geodir_converter_{$this->importer_id}_batch_size", self::BATCH_SIZE );
+
+		return (int) min( self::MAX_BATCH_SIZE, max( self::MIN_BATCH_SIZE, $batch_size ) );
 	}
 
 	/**
@@ -767,6 +861,12 @@ abstract class GeoDir_Converter_Importer {
 		wp_defer_term_counting( true );
 		wp_defer_comment_counting( true );
 
+		$this->cache_addition_suspended = wp_suspend_cache_addition();
+
+		wp_suspend_cache_addition( true );
+
+		add_filter( 'wp_image_editors', array( $this, 'filter_image_editors' ), 9999 );
+
 		// Prevent email notifications on post status transitions.
 		remove_action( 'transition_post_status', array( 'GeoDir_Post_Data', 'transition_post_status' ), 6 );
 
@@ -786,6 +886,41 @@ abstract class GeoDir_Converter_Importer {
 	}
 
 	/**
+	 * Prefer the GD image editor while an import is running.
+	 *
+	 * Imagick can segfault on malformed images, killing the worker with no
+	 * catchable error. GD is sufficient for the thumbnailing imports perform.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param string[] $editors Class names of the available image editors.
+	 * @return string[] Reordered class names.
+	 */
+	public function filter_image_editors( $editors ) {
+		$editors = (array) $editors;
+
+		/**
+		 * Filters whether imports should prefer GD over Imagick.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param bool                      $prefer_gd Whether to prefer GD. Default true.
+		 * @param GeoDir_Converter_Importer $importer  The importer instance.
+		 */
+		$prefer_gd = apply_filters( "geodir_converter_{$this->importer_id}_prefer_gd_editor", true, $this );
+
+		if ( ! $prefer_gd || ! extension_loaded( 'gd' ) ) {
+			return $editors;
+		}
+
+		$editors = array_values( array_diff( $editors, array( 'WP_Image_Editor_GD' ) ) );
+
+		array_unshift( $editors, 'WP_Image_Editor_GD' );
+
+		return $editors;
+	}
+
+	/**
 	 * Restore hooks and flush deferred counts after bulk import.
 	 *
 	 * @since 2.2.0
@@ -793,6 +928,14 @@ abstract class GeoDir_Converter_Importer {
 	public function restore_hooks() {
 		wp_defer_term_counting( false );
 		wp_defer_comment_counting( false );
+
+		wp_suspend_cache_addition( $this->cache_addition_suspended );
+
+		// Only reached when the task returned; a hard crash leaves the marker
+		// in place so the next attempt can attribute the failure.
+		$this->clear_in_flight();
+
+		remove_filter( 'wp_image_editors', array( $this, 'filter_image_editors' ), 9999 );
 
 		// Restore hooks.
 		add_action( 'transition_post_status', array( 'GeoDir_Post_Data', 'transition_post_status' ), 6, 3 );
@@ -898,6 +1041,8 @@ abstract class GeoDir_Converter_Importer {
 				$this->record_failed_item( $source_id, $action, $item_type, $label, sprintf( self::LOG_TEMPLATE_FAILED, $item_type, $label ) );
 				break;
 		}
+
+		$this->maybe_flush_progress();
 	}
 
 	/**
@@ -1301,7 +1446,7 @@ abstract class GeoDir_Converter_Importer {
 			return;
 		}
 
-		$stats       = (array) $this->options_handler->get_option_no_cache( 'stats' );
+		$stats       = (array) $this->options_handler->get_option_no_cache( 'stats', array() );
 		$empty_stats = self::empty_stats();
 		$stats       = wp_parse_args( $stats, $empty_stats );
 
@@ -1328,7 +1473,7 @@ abstract class GeoDir_Converter_Importer {
 	 * }
 	 */
 	public function get_stats() {
-		$stats       = (array) $this->options_handler->get_option_no_cache( 'stats' );
+		$stats       = (array) $this->options_handler->get_option_no_cache( 'stats', array() );
 		$empty_stats = self::empty_stats();
 		$stats       = wp_parse_args( $stats, $empty_stats );
 
@@ -1359,6 +1504,9 @@ abstract class GeoDir_Converter_Importer {
 	/**
 	 * Get the import progress as a percentage.
 	 *
+	 * Always reflects the recorded stats. An import that stopped early reports
+	 * how far it actually got rather than claiming completion.
+	 *
 	 * @since 2.0.2
 	 *
 	 * @return float The import progress percentage (0-100).
@@ -1367,13 +1515,13 @@ abstract class GeoDir_Converter_Importer {
 		$stats = $this->get_stats();
 
 		$total     = (int) $stats['total'];
-		$processed = $stats['succeed'] + $stats['skipped'] + $stats['failed'];
+		$processed = (int) $stats['succeed'] + (int) $stats['skipped'] + (int) $stats['failed'];
 
-		if ( $total == 0 ) {
+		if ( $total <= 0 ) {
 			return $this->background_process->is_in_progress() ? 0 : 100;
-		} else {
-			return $this->background_process->is_in_progress() ? min( round( $processed / $total * 100 ), 100 ) : 100;
 		}
+
+		return (float) min( round( $processed / $total * 100 ), 100 );
 	}
 
 	/**
@@ -1390,6 +1538,13 @@ abstract class GeoDir_Converter_Importer {
 		$this->options_handler->delete_option( 'import_start_time' );
 		$this->options_handler->delete_option( 'failed_items' );
 		$this->options_handler->delete_option( 'paused' );
+		$this->options_handler->delete_option( 'checkpoint' );
+		$this->options_handler->delete_option( 'in_flight' );
+		$this->options_handler->delete_option( 'log_offset' );
+
+		$this->pending_checkpoint = null;
+		$this->in_flight_item     = null;
+		$this->items_since_flush  = 0;
 	}
 
 	/**
@@ -1441,6 +1596,390 @@ abstract class GeoDir_Converter_Importer {
 
 		$this->options_handler->update_option( 'failed_items', $failed_items );
 		$this->pending_failed_items = array();
+	}
+
+	/**
+	 * Write every buffered progress channel to the database.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return void
+	 */
+	public function flush_progress() {
+		$this->flush_stats();
+		$this->flush_logs();
+		$this->flush_failed_items();
+		$this->flush_checkpoint();
+	}
+
+	/**
+	 * Persist buffered progress once enough items have been processed.
+	 *
+	 * Buffered progress is lost if the worker dies mid-batch, so flushing
+	 * periodically bounds that loss and keeps the progress bar moving.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param bool $force Flush regardless of how many items are pending.
+	 * @return void
+	 */
+	public function maybe_flush_progress( $force = false ) {
+		++$this->items_since_flush;
+
+		/**
+		 * Filters how many items are processed between progress flushes.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param int $interval Number of items. Default FLUSH_INTERVAL.
+		 */
+		$interval = (int) apply_filters( "geodir_converter_{$this->importer_id}_flush_interval", self::FLUSH_INTERVAL );
+		$interval = max( 1, $interval );
+
+		if ( ! $force && $this->items_since_flush < $interval ) {
+			return;
+		}
+
+		$this->flush_progress();
+
+		$this->items_since_flush = 0;
+	}
+
+	/**
+	 * Record how far the current paginated task has progressed.
+	 *
+	 * A task's offset only reaches the database once the task returns, so
+	 * without this an interrupted batch restarts from where it began.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param string $action The task action the offset belongs to.
+	 * @param int    $offset The offset to resume from.
+	 * @return void
+	 */
+	public function set_checkpoint( $action, $offset ) {
+		$this->pending_checkpoint = array(
+			'action' => (string) $action,
+			'offset' => max( 0, (int) $offset ),
+		);
+	}
+
+	/**
+	 * Write the pending checkpoint.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return void
+	 */
+	public function flush_checkpoint() {
+		if ( null === $this->pending_checkpoint ) {
+			return;
+		}
+
+		$this->options_handler->update_option( 'checkpoint', $this->pending_checkpoint );
+		$this->pending_checkpoint = null;
+	}
+
+	/**
+	 * Resolve the offset a paginated task should start from.
+	 *
+	 * Prefers a checkpoint left behind by an interrupted attempt over the offset
+	 * carried by the queued task.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param string $action The task action.
+	 * @param array  $task   The queued task.
+	 * @return int The offset to resume from.
+	 */
+	public function resume_offset( $action, array $task ) {
+		$offset     = isset( $task['offset'] ) ? absint( $task['offset'] ) : 0;
+		$checkpoint = $this->options_handler->get_option_no_cache( 'checkpoint' );
+
+		if ( is_array( $checkpoint )
+			&& isset( $checkpoint['action'], $checkpoint['offset'] )
+			&& $action === $checkpoint['action']
+			&& (int) $checkpoint['offset'] > $offset
+		) {
+			return (int) $checkpoint['offset'];
+		}
+
+		return $offset;
+	}
+
+	/**
+	 * Discard the resume checkpoint.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return void
+	 */
+	public function clear_checkpoint() {
+		$this->pending_checkpoint = null;
+		$this->options_handler->delete_option( 'checkpoint' );
+	}
+
+	/**
+	 * Claim an item for processing, guarding against a repeating hard crash.
+	 *
+	 * Written immediately rather than buffered, since the failures this guards
+	 * against take the whole process down. An item claimed more than
+	 * MAX_ITEM_ATTEMPTS times is recorded as failed and skipped.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param string $action    The task action.
+	 * @param int    $source_id The source item ID.
+	 * @param string $item_type Human-readable item type (e.g. 'listing').
+	 * @param string $label     Display label for the item.
+	 * @return bool True to process the item, false if it must be skipped.
+	 */
+	public function claim_item( $action, $source_id, $item_type = 'item', $label = '' ) {
+		$source_id = (int) $source_id;
+
+		// Read the previous attempt's marker once, then keep it: comparing
+		// against the marker this request has written would only ever catch a
+		// record that crashed as the very first item of a batch.
+		if ( ! $this->crashed_item_loaded ) {
+			$this->crashed_item        = $this->options_handler->get_option_no_cache( 'in_flight' );
+			$this->crashed_item_loaded = true;
+		}
+
+		$previous = $this->crashed_item;
+		$attempts = 1;
+
+		if ( is_array( $previous )
+			&& isset( $previous['action'], $previous['source_id'], $previous['attempts'] )
+			&& $action === $previous['action']
+			&& $source_id === (int) $previous['source_id']
+		) {
+			$attempts = (int) $previous['attempts'] + 1;
+		}
+
+		/**
+		 * Filters how many times an item may be attempted before being skipped.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param int $max_attempts Maximum attempts. Default MAX_ITEM_ATTEMPTS.
+		 */
+		$max_attempts = (int) apply_filters( "geodir_converter_{$this->importer_id}_max_item_attempts", self::MAX_ITEM_ATTEMPTS );
+		$max_attempts = max( 1, $max_attempts );
+
+		if ( $attempts > $max_attempts ) {
+			$error = sprintf(
+				/* translators: %d: number of attempts already made. */
+				__( 'Skipped after crashing the import worker %d times. The source record or one of its images cannot be processed on this server.', 'geodir-converter' ),
+				$max_attempts
+			);
+
+			$this->log( sprintf( '%1$s: %2$s — %3$s', $item_type, $label, $error ), 'error' );
+			$this->increase_failed_imports( 1 );
+			$this->record_failed_item( $source_id, $action, $item_type, $label, $error );
+
+			$this->crashed_item = null;
+
+			$this->clear_in_flight();
+			$this->flush_progress();
+
+			return false;
+		}
+
+		$this->in_flight_item = array(
+			'action'    => (string) $action,
+			'source_id' => $source_id,
+			'item_type' => (string) $item_type,
+			'label'     => (string) $label,
+			'attempts'  => $attempts,
+			'timestamp' => time(),
+		);
+
+		$this->options_handler->update_option( 'in_flight', $this->in_flight_item );
+
+		return true;
+	}
+
+	/**
+	 * Clear the in-flight marker once a batch completes cleanly.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return void
+	 */
+	public function clear_in_flight() {
+		$this->in_flight_item = null;
+		$this->crashed_item   = null;
+
+		$this->options_handler->delete_option( 'in_flight' );
+	}
+
+	/**
+	 * Report cumulative task counters to the stats as deltas.
+	 *
+	 * Paginated tasks carry running totals across batches, so adding the
+	 * running total on every batch would count earlier batches again. Only the
+	 * increase since the previous batch is applied.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $task     The task, updated in place with the new totals.
+	 * @param int   $imported Cumulative imported count.
+	 * @param int   $failed   Cumulative failed count.
+	 * @param int   $skipped  Cumulative skipped count.
+	 * @param int   $updated  Optional. Cumulative updated count.
+	 * @return void
+	 */
+	protected function sync_task_counters( array &$task, $imported, $failed, $skipped, $updated = 0 ) {
+		$action   = isset( $task['action'] ) ? (string) $task['action'] : '';
+		$reported = isset( $task['counters_reported'] ) && is_array( $task['counters_reported'] )
+			? $task['counters_reported']
+			: array();
+
+		// A new action starts from a clean baseline.
+		if ( ! isset( $reported['action'] ) || $reported['action'] !== $action ) {
+			$reported = array();
+		}
+
+		$reported = wp_parse_args(
+			$reported,
+			array(
+				'imported' => 0,
+				'failed'   => 0,
+				'skipped'  => 0,
+				'updated'  => 0,
+			)
+		);
+
+		$totals = array(
+			'imported' => max( 0, (int) $imported ),
+			'failed'   => max( 0, (int) $failed ),
+			'skipped'  => max( 0, (int) $skipped ),
+			'updated'  => max( 0, (int) $updated ),
+		);
+
+		$succeed = max( 0, $totals['imported'] - (int) $reported['imported'] )
+			+ max( 0, $totals['updated'] - (int) $reported['updated'] );
+
+		if ( $succeed > 0 ) {
+			$this->increase_succeed_imports( $succeed );
+		}
+
+		$failed_delta = max( 0, $totals['failed'] - (int) $reported['failed'] );
+
+		if ( $failed_delta > 0 ) {
+			$this->increase_failed_imports( $failed_delta );
+		}
+
+		$skipped_delta = max( 0, $totals['skipped'] - (int) $reported['skipped'] );
+
+		if ( $skipped_delta > 0 ) {
+			$this->increase_skipped_imports( $skipped_delta );
+		}
+
+		$task['imported'] = $totals['imported'];
+		$task['failed']   = $totals['failed'];
+		$task['skipped']  = $totals['skipped'];
+		$task['updated']  = $totals['updated'];
+
+		$totals['action']           = $action;
+		$task['counters_reported']  = $totals;
+	}
+
+	/**
+	 * Read a field from an item that may be an object or an array.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param mixed  $item The item.
+	 * @param string $key  The field name.
+	 * @return mixed The field value, or an empty string when absent.
+	 */
+	protected function get_item_field( $item, $key ) {
+		if ( is_object( $item ) && isset( $item->{$key} ) ) {
+			return $item->{$key};
+		}
+
+		if ( is_array( $item ) && isset( $item[ $key ] ) ) {
+			return $item[ $key ];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Process a queued batch of items, guarding each against a hard crash.
+	 *
+	 * Pass a closure declared inside the importer so it keeps access to that
+	 * class's private members.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array    $items   The items to process.
+	 * @param callable $handler Receives an item and returns an IMPORT_STATUS_* code.
+	 * @param array    $args    {
+	 *     Optional. Arguments describing the items.
+	 *
+	 *     @type string   $item_type      Human-readable item type. Default 'listing'.
+	 *     @type string   $action         Task action. Default ACTION_IMPORT_LISTINGS.
+	 *     @type string   $id_key         Field holding the source ID. Default 'ID'.
+	 *     @type string   $title_key      Field holding the title. Default 'post_title'.
+	 *     @type callable $label_callback Builds the display label from the item.
+	 * }
+	 * @return false Always false, so the queue drops the completed task.
+	 */
+	protected function import_queued_items( array $items, callable $handler, array $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'item_type'      => 'listing',
+				'action'         => self::ACTION_IMPORT_LISTINGS,
+				'id_key'         => 'ID',
+				'title_key'      => 'post_title',
+				'label_callback' => null,
+			)
+		);
+
+		try {
+			foreach ( $items as $item ) {
+				$source_id = (int) $this->get_item_field( $item, $args['id_key'] );
+
+				$label = is_callable( $args['label_callback'] )
+					? (string) call_user_func( $args['label_callback'], $item )
+					: (string) $this->get_item_field( $item, $args['title_key'] );
+
+				if ( ! $this->claim_item( $args['action'], $source_id, $args['item_type'], $label ) ) {
+					continue;
+				}
+
+				$this->process_import_result(
+					call_user_func( $handler, $item ),
+					$args['item_type'],
+					$label,
+					$source_id,
+					$args['action']
+				);
+			}
+		} finally {
+			$this->clear_in_flight();
+			$this->flush_progress();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the current batch should stop early and requeue the remainder.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return bool True if the batch should yield.
+	 */
+	public function should_yield() {
+		if ( ! $this->background_process instanceof GeoDir_Converter_Background_Process ) {
+			return false;
+		}
+
+		return $this->background_process->should_yield();
 	}
 
 	/**
@@ -1585,7 +2124,10 @@ abstract class GeoDir_Converter_Importer {
 
 		$skip_logs = max( 0, (int) $skip_logs );
 
-		return array_slice( $logs, $skip_logs );
+		// Older entries may have been discarded, so rebase the caller's index.
+		$discarded = (int) $this->options_handler->get_option_no_cache( 'log_offset', 0 );
+
+		return array_slice( $logs, max( 0, $skip_logs - $discarded ) );
 	}
 
 	/**
@@ -1624,8 +2166,28 @@ abstract class GeoDir_Converter_Importer {
 			return;
 		}
 
-		$logs = $this->options_handler->get_option_no_cache( 'import_log', array() );
+		$logs = (array) $this->options_handler->get_option_no_cache( 'import_log', array() );
 		$logs = array_merge( $logs, $this->logs_buffer );
+
+		/**
+		 * Filters how many log entries an import retains.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param int $max_entries Maximum entries. Default MAX_LOG_ENTRIES.
+		 */
+		$max_entries = (int) apply_filters( "geodir_converter_{$this->importer_id}_max_log_entries", self::MAX_LOG_ENTRIES );
+
+		if ( $max_entries > 0 && count( $logs ) > $max_entries ) {
+			$discarded = count( $logs ) - $max_entries;
+			$logs      = array_slice( $logs, $discarded );
+
+			$this->options_handler->update_option(
+				'log_offset',
+				(int) $this->options_handler->get_option_no_cache( 'log_offset', 0 ) + $discarded
+			);
+		}
+
 		$this->options_handler->update_option( 'import_log', $logs );
 		$this->logs_buffer = array();
 	}

--- a/includes/importers/class-geodir-converter-adirectory.php
+++ b/includes/importers/class-geodir-converter-adirectory.php
@@ -1480,16 +1480,12 @@ class GeoDir_Converter_aDirectory extends GeoDir_Converter_Importer {
 	public function task_import_listings( $task ) {
 		$listings = isset( $task['listings'] ) && ! empty( $task['listings'] ) ? (array) $task['listings'] : array();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$status = $this->import_single_listing( $listing );
-
-			$this->process_import_result( $status, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) {
+				return $this->import_single_listing( $listing );
+			}
+		);
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-background-process.php
+++ b/includes/importers/class-geodir-converter-background-process.php
@@ -37,6 +37,22 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 	public const MAX_REQUEST_TIMEOUT = 30;
 
 	/**
+	 * Soft wall-clock budget for a single batch, in seconds.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	public const BATCH_TIME_LIMIT = 20;
+
+	/**
+	 * Seconds of headroom left before the PHP execution limit.
+	 *
+	 * @since 2.2.1
+	 * @var int
+	 */
+	public const YIELD_HEADROOM = 10;
+
+	/**
 	 * The importer instance.
 	 *
 	 * @var GeoDir_Converter_Importer
@@ -74,10 +90,57 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 	 */
 	protected function time_left() {
 		if ( $this->max_execution_time > 0 ) {
-			return $this->start_time + $this->max_execution_time - time();
+			return $this->batch_start_time() + $this->max_execution_time - time();
 		} else {
 			return self::MAX_REQUEST_TIMEOUT;
 		}
+	}
+
+	/**
+	 * Get the batch start time, initialising it when the batch was not started
+	 * through handle().
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return int Unix timestamp.
+	 */
+	protected function batch_start_time() {
+		if ( $this->start_time <= 0 ) {
+			$this->start_time = time();
+		}
+
+		return $this->start_time;
+	}
+
+	/**
+	 * Whether the current batch should stop early and requeue the remainder.
+	 *
+	 * Lets an importer break out of a long item loop before the request is
+	 * killed, instead of losing the whole batch.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @return bool True if the batch should yield.
+	 */
+	public function should_yield() {
+		/**
+		 * Filters the soft wall-clock budget for a single batch.
+		 *
+		 * @since 2.2.1
+		 *
+		 * @param int $budget Budget in seconds. Default BATCH_TIME_LIMIT.
+		 */
+		$budget = (int) apply_filters( $this->identifier . '_batch_time_limit', self::BATCH_TIME_LIMIT );
+
+		if ( $budget > 0 && ( time() - $this->batch_start_time() ) >= $budget ) {
+			return true;
+		}
+
+		if ( $this->time_left() <= self::YIELD_HEADROOM ) {
+			return true;
+		}
+
+		return $this->memory_exceeded();
 	}
 
 	/**
@@ -270,7 +333,7 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 				throw new GeoDir_Converter_Execution_Time_Exception(
 					sprintf(
 						/* translators: %d: Maximum execution time in seconds */
-						__( 'Maximum execution time is set to %d seconds.', 'geodir-booking' ),
+						__( 'Maximum execution time is set to %d seconds.', 'geodir-converter' ),
 						$timeout
 					)
 				);
@@ -281,11 +344,14 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 
 			if ( method_exists( $this->importer, $import_method ) ) {
 				$this->importer->suspend_hooks();
-				$result = $this->importer->$import_method( $task );
-				$this->importer->restore_hooks();
-				$this->importer->flush_stats();
-				$this->importer->flush_logs();
-				$this->importer->flush_failed_items();
+
+				try {
+					$result = $this->importer->$import_method( $task );
+				} finally {
+					$this->importer->restore_hooks();
+					$this->importer->flush_progress();
+				}
+
 				return $result;
 			}
 
@@ -301,9 +367,7 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 			add_filter( $this->identifier . '_time_exceeded', '__return_true' );
 
 			$this->importer->log( $e->getMessage(), 'warning' );
-			$this->importer->flush_stats();
-			$this->importer->flush_logs();
-			$this->importer->flush_failed_items();
+			$this->importer->flush_progress();
 
 			/**
 			 * Edge case: Hosts with low `max_execution_time` settings.
@@ -314,9 +378,7 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 			return $task;
 		} catch ( Exception $e ) {
 			$this->importer->log( 'Import error: ' . $e->getMessage(), 'error' );
-			$this->importer->flush_stats();
-			$this->importer->flush_logs();
-			$this->importer->flush_failed_items();
+			$this->importer->flush_progress();
 		}
 
 		return false;
@@ -408,7 +470,7 @@ class GeoDir_Converter_Background_Process extends GeoDir_Background_Process {
 
 		// Adjust stats: subtract failed count so progress recalculates correctly.
 		$failed_count = count( $tasks );
-		$stats        = (array) $this->importer->options_handler->get_option_no_cache( 'stats' );
+		$stats        = (array) $this->importer->options_handler->get_option_no_cache( 'stats', array() );
 		$empty_stats  = $this->importer->empty_stats();
 		$stats        = wp_parse_args( $stats, $empty_stats );
 

--- a/includes/importers/class-geodir-converter-business-directory.php
+++ b/includes/importers/class-geodir-converter-business-directory.php
@@ -578,18 +578,19 @@ class GeoDir_Converter_Business_Directory extends GeoDir_Converter_Importer {
 	public function task_import_listings( array $task ) {
 		global $wpdb;
 
-		$this->log( __( 'Starting listings import...', 'geodir-converter' ) );
-
-		$offset         = isset( $task['offset'] ) ? absint( $task['offset'] ) : 0;
+		$offset         = $this->resume_offset( self::ACTION_IMPORT_LISTINGS, $task );
 		$batch_size     = $this->get_batch_size();
 		$total_listings = $this->count_listings();
 
-		if ( 0 === $total_listings ) {
-			$this->log( __( 'No listings to import. Skipping...', 'geodir-converter' ) );
-			return $this->next_task( $task );
+		if ( 0 === $offset ) {
+			$this->log( __( 'Starting listings import...', 'geodir-converter' ) );
+			$this->flush_progress();
 		}
 
-		wp_suspend_cache_addition( true );
+		if ( 0 === $total_listings ) {
+			$this->log( __( 'No listings to import. Skipping...', 'geodir-converter' ) );
+			return $this->complete_listings( $task );
+		}
 
 		$listings = $wpdb->get_results(
 			$wpdb->prepare(
@@ -597,6 +598,7 @@ class GeoDir_Converter_Business_Directory extends GeoDir_Converter_Importer {
                 FROM {$wpdb->posts}
                 WHERE post_type = %s
                 AND post_status IN (" . implode( ',', array_fill( 0, count( $this->post_statuses ), '%s' ) ) . ')
+                ORDER BY ID ASC
                 LIMIT %d OFFSET %d',
 				array_merge(
 					array( self::POST_TYPE_LISTING ),
@@ -608,29 +610,60 @@ class GeoDir_Converter_Business_Directory extends GeoDir_Converter_Importer {
 
 		if ( empty( $listings ) ) {
 			$this->log( __( 'Finished importing listings.', 'geodir-converter' ) );
-			return $this->next_task( $task );
+			return $this->complete_listings( $task );
 		}
 
-		foreach ( $listings as $listing ) {
-			$post = get_post( $listing->ID );
-			if ( ! $post ) {
-				$this->process_import_result( self::IMPORT_STATUS_FAILED, 'listing', $listing->post_title, $listing->ID );
-				continue;
+		$processed = 0;
+		$remaining = count( $listings );
+
+		try {
+			foreach ( $listings as $listing ) {
+				++$processed;
+				--$remaining;
+
+				if ( $this->claim_item( self::ACTION_IMPORT_LISTINGS, $listing->ID, 'listing', $listing->post_title ) ) {
+					$post = get_post( $listing->ID );
+
+					if ( ! $post ) {
+						$this->process_import_result( self::IMPORT_STATUS_FAILED, 'listing', $listing->post_title, $listing->ID );
+					} else {
+						$this->process_import_result( $this->import_single_listing( $post ), 'listing', $post->post_title, $post->ID );
+					}
+				}
+
+				$this->set_checkpoint( self::ACTION_IMPORT_LISTINGS, $offset + $processed );
+
+				if ( $remaining > 0 && $this->should_yield() ) {
+					break;
+				}
 			}
-
-			$result = $this->import_single_listing( $post );
-
-			$this->process_import_result( $result, 'listing', $post->post_title, $post->ID );
+		} finally {
+			$this->clear_in_flight();
+			$this->flush_progress();
 		}
 
-		$this->flush_failed_items();
+		$next_offset = $offset + $processed;
 
-		$complete = ( $offset + $batch_size >= $total_listings );
-
-		if ( ! $complete ) {
-			$task['offset'] = $offset + $batch_size;
+		if ( $next_offset < $total_listings ) {
+			$task['offset'] = $next_offset;
 			return $task;
 		}
+
+		return $this->complete_listings( $task );
+	}
+
+	/**
+	 * Finish the listings phase and move on.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $task The current task data.
+	 * @return array|false The next task, or false when the import is complete.
+	 */
+	private function complete_listings( array $task ) {
+		$this->clear_in_flight();
+		$this->clear_checkpoint();
+		$this->flush_progress();
 
 		return $this->next_task( $task );
 	}
@@ -779,7 +812,7 @@ class GeoDir_Converter_Business_Directory extends GeoDir_Converter_Importer {
 			}
 		}
 
-		return $is_update ? GeoDir_Converter_Importer::IMPORT_STATUS_SKIPPED : GeoDir_Converter_Importer::IMPORT_STATUS_SUCCESS;
+		return $is_update ? GeoDir_Converter_Importer::IMPORT_STATUS_UPDATED : GeoDir_Converter_Importer::IMPORT_STATUS_SUCCESS;
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-csv.php
+++ b/includes/importers/class-geodir-converter-csv.php
@@ -678,13 +678,23 @@ class GeoDir_Converter_CSV extends GeoDir_Converter_Importer {
 			return false;
 		}
 
-		foreach ( $rows as $row_index => $row ) {
-			$result = $this->import_single_listing( $row, $column_mapping, $post_type, $settings );
+		try {
+			foreach ( $rows as $row_index => $row ) {
+				/* translators: %d: CSV row number. */
+				$label = sprintf( __( 'Row %d', 'geodir-converter' ), (int) $row_index + 1 );
 
-			$this->process_import_result( $result['status'], 'listing', $result['post_title'], $row_index );
+				if ( ! $this->claim_item( self::ACTION_IMPORT_LISTINGS, $row_index, 'listing', $label ) ) {
+					continue;
+				}
+
+				$result = $this->import_single_listing( $row, $column_mapping, $post_type, $settings );
+
+				$this->process_import_result( $result['status'], 'listing', $result['post_title'], $row_index );
+			}
+		} finally {
+			$this->clear_in_flight();
+			$this->flush_progress();
 		}
-
-		$this->flush_failed_items();
 
 		return false;
 	}

--- a/includes/importers/class-geodir-converter-directories-pro.php
+++ b/includes/importers/class-geodir-converter-directories-pro.php
@@ -1269,16 +1269,12 @@ class GeoDir_Converter_Directories_Pro extends GeoDir_Converter_Importer {
 	public function task_import_listings( $task ) {
 		$listings = isset( $task['listings'] ) && ! empty( $task['listings'] ) ? (array) $task['listings'] : array();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$status = $this->import_single_listing( $listing );
-
-			$this->process_import_result( $status, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) {
+				return $this->import_single_listing( $listing );
+			}
+		);
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-directorist.php
+++ b/includes/importers/class-geodir-converter-directorist.php
@@ -672,27 +672,27 @@ class GeoDir_Converter_Directorist extends GeoDir_Converter_Importer {
 			return false;
 		}
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$result = $this->import_single_listing( $listing );
+		$this->import_queued_items(
+			$listings,
+			function ( $listing ) use ( &$mapping ) {
+				$result = $this->import_single_listing( $listing );
 
-			$this->process_import_result( $result['status'], 'listing', $title, $listing->ID );
-
-			// Update listings mapping.
-			if ( in_array( $result['status'], array( self::IMPORT_STATUS_SUCCESS, self::IMPORT_STATUS_UPDATED ), true ) ) {
-				if ( ! empty( $result['gd_post_id'] ) && ! empty( $result['gd_package_id'] ) ) {
-					$mapping[ (int) $listing->ID ] = array(
-						'gd_post_id'    => $result['gd_post_id'],
-						'gd_package_id' => $result['gd_package_id'],
-					);
+				// Update listings mapping.
+				if ( in_array( $result['status'], array( self::IMPORT_STATUS_SUCCESS, self::IMPORT_STATUS_UPDATED ), true ) ) {
+					if ( ! empty( $result['gd_post_id'] ) && ! empty( $result['gd_package_id'] ) ) {
+						$mapping[ (int) $listing->ID ] = array(
+							'gd_post_id'    => $result['gd_post_id'],
+							'gd_package_id' => $result['gd_package_id'],
+						);
+					}
 				}
+
+				return $result['status'];
 			}
-		}
+		);
 
 		// Update listings mapping.
 		$this->options_handler->update_option( 'listings_mapping', $mapping );
-
-		$this->flush_failed_items();
 
 		return false;
 	}
@@ -2238,9 +2238,7 @@ class GeoDir_Converter_Directorist extends GeoDir_Converter_Importer {
 			do_action( 'geodir_cp_after_import_custom_field_data', $field, $exists );
 		}
 
-		$this->increase_succeed_imports( $imported + $updated );
-		$this->increase_skipped_imports( $skipped );
-		$this->increase_failed_imports( $failed );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped, $updated );
 
 		$this->log(
 			wp_sprintf(

--- a/includes/importers/class-geodir-converter-edirectory.php
+++ b/includes/importers/class-geodir-converter-edirectory.php
@@ -736,9 +736,7 @@ class GeoDir_Converter_EDirectory extends GeoDir_Converter_Importer {
 		// Save packages mapping.
 		$this->options_handler->update_option( 'packages_mapping', $packages_mapping );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$this->log( sprintf( self::LOG_TEMPLATE_FINISHED, 'Packages', count( $products ), $imported, $updated, $skipped, $failed ), 'success' );
 
@@ -978,9 +976,7 @@ class GeoDir_Converter_EDirectory extends GeoDir_Converter_Importer {
 			);
 		}
 
-		$this->increase_succeed_imports( $imported + $updated );
-		$this->increase_skipped_imports( $skipped );
-		$this->increase_failed_imports( $failed );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped, $updated );
 
 		$this->log(
 			sprintf( self::LOG_TEMPLATE_FINISHED, 'Fields', count( $fields ), $imported, $updated, $skipped, $failed ),
@@ -1542,12 +1538,17 @@ class GeoDir_Converter_EDirectory extends GeoDir_Converter_Importer {
 				$data['product'] = trim( $listing['product'] );
 			}
 
+			if ( ! $this->claim_item( self::ACTION_IMPORT_LISTINGS, $listing['id'], $module, $title ) ) {
+				continue;
+			}
+
 			$status = $this->$method( $data, $category_mapping, $packages_mapping );
 
 			$this->process_import_result( $status, $module, $title, $listing['id'] );
 		}
 
-		$this->flush_failed_items();
+		$this->clear_in_flight();
+		$this->flush_progress();
 
 		return false;
 	}
@@ -1683,7 +1684,7 @@ class GeoDir_Converter_EDirectory extends GeoDir_Converter_Importer {
 
 		// Handle test mode.
 		if ( $this->is_test_mode() ) {
-			return $is_update ? self::IMPORT_STATUS_SKIPPED : self::IMPORT_STATUS_SUCCESS;
+			return $is_update ? self::IMPORT_STATUS_UPDATED : self::IMPORT_STATUS_SUCCESS;
 		}
 
 		// Delete existing media if updating.
@@ -1918,7 +1919,7 @@ class GeoDir_Converter_EDirectory extends GeoDir_Converter_Importer {
 
 		// Handle test mode.
 		if ( $this->is_test_mode() ) {
-			return $is_update ? self::IMPORT_STATUS_SKIPPED : self::IMPORT_STATUS_SUCCESS;
+			return $is_update ? self::IMPORT_STATUS_UPDATED : self::IMPORT_STATUS_SUCCESS;
 		}
 
 		// Delete existing media if updating.

--- a/includes/importers/class-geodir-converter-hivepress.php
+++ b/includes/importers/class-geodir-converter-hivepress.php
@@ -902,16 +902,12 @@ class GeoDir_Converter_HivePress extends GeoDir_Converter_Importer {
 	public function task_import_listings( $task ) {
 		$listings = isset( $task['listings'] ) && ! empty( $task['listings'] ) ? (array) $task['listings'] : array();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$status = $this->import_single_listing( $listing );
-
-			$this->process_import_result( $status, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) {
+				return $this->import_single_listing( $listing );
+			}
+		);
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-listify.php
+++ b/includes/importers/class-geodir-converter-listify.php
@@ -812,16 +812,12 @@ class GeoDir_Converter_Listify extends GeoDir_Converter_Importer {
 	public function task_import_listings( $task ) {
 		$listings = isset( $task['listings'] ) && ! empty( $task['listings'] ) ? (array) $task['listings'] : array();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$result = $this->import_single_listing( $listing );
-
-			$this->process_import_result( $result, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) {
+				return $this->import_single_listing( $listing );
+			}
+		);
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-listingpro.php
+++ b/includes/importers/class-geodir-converter-listingpro.php
@@ -1705,16 +1705,12 @@ class GeoDir_Converter_ListingPro extends GeoDir_Converter_Importer {
 
 		$packages_mapping = $this->is_test_mode() ? array() : $this->get_packages_mapping();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$status = $this->import_single_listing( $listing, $packages_mapping );
-
-			$this->process_import_result( $status, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) use ( $packages_mapping ) {
+				return $this->import_single_listing( $listing, $packages_mapping );
+			}
+		);
 	}
 
 	/**
@@ -1918,7 +1914,7 @@ class GeoDir_Converter_ListingPro extends GeoDir_Converter_Importer {
 		}
 
 		if ( $this->is_test_mode() ) {
-			return $is_update ? self::IMPORT_STATUS_SKIPPED : self::IMPORT_STATUS_SUCCESS;
+			return $is_update ? self::IMPORT_STATUS_UPDATED : self::IMPORT_STATUS_SUCCESS;
 		}
 
 		if ( $is_update ) {

--- a/includes/importers/class-geodir-converter-mylisting.php
+++ b/includes/importers/class-geodir-converter-mylisting.php
@@ -1291,16 +1291,12 @@ class GeoDir_Converter_MyListing extends GeoDir_Converter_Importer {
 	public function task_import_listings( $task ) {
 		$listings = isset( $task['listings'] ) && ! empty( $task['listings'] ) ? (array) $task['listings'] : array();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$status = $this->import_single_listing( $listing );
-
-			$this->process_import_result( $status, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) {
+				return $this->import_single_listing( $listing );
+			}
+		);
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-pmd.php
+++ b/includes/importers/class-geodir-converter-pmd.php
@@ -684,9 +684,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_users );
 
@@ -943,9 +941,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		// Save packages mapping.
 		$this->options_handler->update_option( 'packages_mapping', $packages_mapping );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_products );
 
@@ -1681,9 +1677,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_categories );
 
@@ -1840,9 +1834,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_categories );
 
@@ -2000,9 +1992,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_categories );
 
@@ -2080,7 +2070,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 
 		wp_suspend_cache_addition( true );
 
-		$offset         = isset( $task['offset'] ) ? absint( $task['offset'] ) : 0;
+		$offset         = $this->resume_offset( self::ACTION_IMPORT_LISTINGS, $task );
 		$total_listings = isset( $task['total_listings'] ) ? absint( $task['total_listings'] ) : 0;
 		$batch_size     = absint( $this->get_batch_size() );
 		$fields         = isset( $task['mapped_fields'] ) ? (array) $task['mapped_fields'] : array();
@@ -2118,21 +2108,43 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 			return $this->next_task( $task );
 		}
 
-		foreach ( $listings as $pmd_listing ) {
-			$listing = $this->import_single_listing( $pmd_listing, $fields );
+		$processed = 0;
+		$remaining = count( $listings );
 
-			$this->process_import_result( $listing, 'listing', $pmd_listing->title, $pmd_listing->id );
+		try {
+			foreach ( $listings as $pmd_listing ) {
+				++$processed;
+				--$remaining;
+
+				if ( $this->claim_item( self::ACTION_IMPORT_LISTINGS, $pmd_listing->id, 'listing', $pmd_listing->title ) ) {
+					$this->process_import_result(
+						$this->import_single_listing( $pmd_listing, $fields ),
+						'listing',
+						$pmd_listing->title,
+						$pmd_listing->id
+					);
+				}
+
+				$this->set_checkpoint( self::ACTION_IMPORT_LISTINGS, $offset + $processed );
+
+				if ( $remaining > 0 && $this->should_yield() ) {
+					break;
+				}
+			}
+		} finally {
+			$this->clear_in_flight();
+			$this->flush_progress();
 		}
 
-		$this->flush_failed_items();
+		$next_offset = $offset + $processed;
 
-		$complete = ( $offset + $batch_size >= $total_listings );
-
-		if ( ! $complete ) {
+		if ( $next_offset < $total_listings ) {
 			// Continue import with the next batch.
-			$task['offset'] = $offset + $batch_size;
+			$task['offset'] = $next_offset;
 			return $task;
 		}
+
+		$this->clear_checkpoint();
 
 		return $this->next_task( $task );
 	}
@@ -2285,7 +2297,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$listings_mapping[ (int) $listing->id ] = (int) $gd_post_id;
 		$this->options_handler->update_option( 'listings_mapping', $listings_mapping );
 
-		return $is_update ? GeoDir_Converter_Importer::IMPORT_STATUS_SKIPPED : GeoDir_Converter_Importer::IMPORT_STATUS_SUCCESS;
+		return $is_update ? GeoDir_Converter_Importer::IMPORT_STATUS_UPDATED : GeoDir_Converter_Importer::IMPORT_STATUS_SUCCESS;
 	}
 
 	/**
@@ -2421,7 +2433,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$db    = $this->get_db_connection();
 		$table = $this->db_prefix . 'listings_categories';
 
-		$category_mapping   = (array) $this->options_handler->get_option_no_cache( 'category_mapping' );
+		$category_mapping   = (array) $this->options_handler->get_option_no_cache( 'category_mapping', array() );
 		$listing_categories = $db->get_results(
 			$db->prepare(
 				"SELECT cat_id FROM {$table} c WHERE c.list_id = %d ORDER BY c.cat_id",
@@ -2568,6 +2580,10 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		}
 
 		foreach ( $events as $event ) {
+			if ( ! $this->claim_item( self::ACTION_IMPORT_EVENTS, $event->id, 'event', $event->title ) ) {
+				continue;
+			}
+
 			$gd_event_id = ! $this->is_test_mode() ? $this->get_gd_listing_id( $event->id, 'pmd_id', $post_type ) : false;
 			$is_update   = ! empty( $gd_event_id );
 
@@ -2701,9 +2717,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$this->flush_failed_items();
 
@@ -2892,9 +2906,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_reviews );
 
@@ -2986,6 +2998,9 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		}
 
 		foreach ( $posts as $post ) {
+			if ( ! $this->claim_item( self::ACTION_IMPORT_POSTS, $post->id, 'post', $post->title ) ) {
+				continue;
+			}
 
 			$post_id   = ! $this->is_test_mode() ? $this->get_gd_post_id( $post->id, 'pmd_blog_id' ) : false;
 			$is_update = ! empty( $post_id );
@@ -3058,9 +3073,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_posts );
 
@@ -3106,7 +3119,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$db         = $this->get_db_connection();
 		$cats_table = $this->db_prefix . $table . '_categories_lookup';
 
-		$category_mapping = (array) $this->options_handler->get_option_no_cache( $table . '_category_mapping' );
+		$category_mapping = (array) $this->options_handler->get_option_no_cache( $table . '_category_mapping', array() );
 
 		$categories_lookup = $db->get_results(
 			$db->prepare(
@@ -3236,9 +3249,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_pages );
 
@@ -3408,9 +3419,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_comments );
 
@@ -3569,9 +3578,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_discounts );
 
@@ -3793,9 +3800,7 @@ class GeoDir_Converter_PMD extends GeoDir_Converter_Importer {
 		$task['failed']   = absint( $failed );
 		$task['skipped']  = absint( $skipped );
 
-		$this->increase_succeed_imports( $imported );
-		$this->increase_failed_imports( $failed );
-		$this->increase_skipped_imports( $skipped );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$complete = ( $offset + $batch_size >= $total_invoices );
 

--- a/includes/importers/class-geodir-converter-ulisting.php
+++ b/includes/importers/class-geodir-converter-ulisting.php
@@ -1335,16 +1335,12 @@ class GeoDir_Converter_uListing extends GeoDir_Converter_Importer {
 	public function task_import_listings( $task ) {
 		$listings = isset( $task['listings'] ) && ! empty( $task['listings'] ) ? (array) $task['listings'] : array();
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$status = $this->import_single_listing( $listing );
-
-			$this->process_import_result( $status, 'listing', $title, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) {
+				return $this->import_single_listing( $listing );
+			}
+		);
 	}
 
 	/**

--- a/includes/importers/class-geodir-converter-vantage.php
+++ b/includes/importers/class-geodir-converter-vantage.php
@@ -512,9 +512,7 @@ class GeoDir_Converter_Vantage extends GeoDir_Converter_Importer {
 			}
 		}
 
-		$this->increase_succeed_imports( $imported + $updated );
-		$this->increase_skipped_imports( $skipped );
-		$this->increase_failed_imports( $failed );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped, $updated );
 
 		$this->log(
 			sprintf(
@@ -679,9 +677,7 @@ class GeoDir_Converter_Vantage extends GeoDir_Converter_Importer {
 
 		wp_suspend_cache_addition( false );
 
-		$this->increase_succeed_imports( (int) $imported );
-		$this->increase_skipped_imports( (int) $skipped );
-		$this->increase_failed_imports( (int) $failed );
+		$this->sync_task_counters( $task, $imported, $failed, $skipped );
 
 		$this->log(
 			sprintf(
@@ -1188,25 +1184,25 @@ class GeoDir_Converter_Vantage extends GeoDir_Converter_Importer {
 			return false;
 		}
 
-		foreach ( $listings as $listing ) {
-			$title  = $listing->post_title;
-			$result = $this->import_single_listing( $listing );
+		$this->import_queued_items(
+			$listings,
+			function ( $listing ) use ( &$mapping ) {
+				$result = $this->import_single_listing( $listing );
 
-			$this->process_import_result( $result['status'], 'listing', $title, $listing->ID );
+				// Update listings mapping.
+				if ( in_array( $result['status'], array( self::IMPORT_STATUS_SUCCESS, self::IMPORT_STATUS_UPDATED ), true ) ) {
+					$mapping[ (int) $listing->ID ] = array(
+						'gd_post_id'    => $result['gd_post_id'],
+						'gd_package_id' => $result['gd_package_id'],
+					);
+				}
 
-			// Update listings mapping.
-			if ( in_array( $result['status'], array( self::IMPORT_STATUS_SUCCESS, self::IMPORT_STATUS_UPDATED ), true ) ) {
-				$mapping[ (int) $listing->ID ] = array(
-					'gd_post_id'    => $result['gd_post_id'],
-					'gd_package_id' => $result['gd_package_id'],
-				);
+				return $result['status'];
 			}
-		}
+		);
 
 		// Update listings mapping.
 		$this->options_handler->update_option( 'listings_mapping', $mapping );
-
-		$this->flush_failed_items();
 
 		return false;
 	}

--- a/includes/importers/class-geodir-converter-wp-residence.php
+++ b/includes/importers/class-geodir-converter-wp-residence.php
@@ -2137,16 +2137,18 @@ class GeoDir_Converter_WP_Residence extends GeoDir_Converter_Importer {
 
 		$packages_mapping = $this->is_test_mode() ? array() : $this->get_packages_mapping();
 
-		foreach ( $listings as $listing ) {
-			$label  = $listing->post_title . ' (#' . $listing->ID . ')';
-			$status = $this->import_single_listing( $listing, $packages_mapping );
-
-			$this->process_import_result( $status, 'property', $label, $listing->ID );
-		}
-
-		$this->flush_failed_items();
-
-		return false;
+		return $this->import_queued_items(
+			$listings,
+			function ( $listing ) use ( $packages_mapping ) {
+				return $this->import_single_listing( $listing, $packages_mapping );
+			},
+			array(
+				'item_type'      => 'property',
+				'label_callback' => function ( $listing ) {
+					return $listing->post_title . ' (#' . $listing->ID . ')';
+				},
+			)
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -34,6 +34,17 @@ Currently supported directories:
 
 == Changelog ==
 
+= 2.2.1 - TBD =
+* Import no longer stalls silently when a record crashes the PHP worker - FIXED
+* Imports now prefer GD over Imagick, which can crash on malformed images - CHANGED
+* Interrupted batches resume from a checkpoint instead of replaying from the start - FIXED
+* Progress, logs and failed items are saved during a batch, not only at the end - CHANGED
+* Listings query was missing an ORDER BY, which could skip or duplicate records - FIXED
+* Stats were counted repeatedly across batches in paginated imports - FIXED
+* Progress reported 100% for an import that stopped early - FIXED
+* Updated listings were logged and counted as skipped - FIXED
+* Import log is capped at 1000 entries to keep large imports fast - CHANGED
+
 = 2.2.0 - 2026-04-09 =
 * Added support for importing listings from WP Residence theme - ADDED
 * Added support for importing listings from MyListing theme - ADDED


### PR DESCRIPTION
An import could stall with no error at all: a record that crashed the PHP worker took the buffered progress with it, the queued task's offset never advanced, and the batch replayed the same record forever. Because the crash was below PHP's error handling, nothing was logged.

- Claim each record before processing it, so one that repeatedly kills the worker is recorded as failed and skipped instead of blocking the import
- Prefer GD over Imagick while importing; Imagick can segfault on malformed images, which no PHP-level error handling can catch
- Flush progress, logs and failed items during a batch rather than only when it returns, and checkpoint the offset so an interrupted batch resumes where it stopped
- Yield out of long item loops before the request is killed
- Add ORDER BY to the Business Directory listings query; offset pagination without it could skip or duplicate records
- Report task counters as deltas; paginated tasks were adding their running total on every batch, inflating the stats
- Report real progress instead of 100% for an import that stopped early
- Return UPDATED rather than SKIPPED for listings that were updated
- Cap the import log, and restore hooks and cache addition when a task throws